### PR TITLE
Allow per-test directories under data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,63 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# PyCharm
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,8 @@ in this order:
 
 - ``tests/test_one/test_func/``
 - ``tests/test_one/``
+- ``tests/data/test_one/test_func/``
+- ``tests/data/test_one/``
 - ``tests/data/``
 
 The path to the first existing file (or directory) is returned as a
@@ -88,6 +90,9 @@ the following directories are searched for a file or directory with the name
 - ``tests/test_two/TestClass/test_method/``
 - ``tests/test_two/TestClass/``
 - ``tests/test_two/``
+- ``tests/data/test_two/TestClass/test_method/``
+- ``tests/data/test_two/TestClass/``
+- ``tests/data/test_two/``
 - ``tests/data/``
 
 Here, this would return the path

--- a/pytest_datadir_ng.py
+++ b/pytest_datadir_ng.py
@@ -36,15 +36,22 @@ import pytest
 class _Datadir(object):
     def __init__(self, request):
         basedir = request.fspath.dirpath()
-        testdir = basedir.join(request.module.__name__)
+        datadir = basedir.join("data")
 
-        self._datadirs = [testdir, basedir.join("data")]
+        self._datadirs = []
 
-        if request.cls is not None:
-            clsdir = testdir.join(request.cls.__name__)
-            self._datadirs[:0] = [clsdir.join(request.function.__name__), clsdir]
-        else:
-            self._datadirs.insert(0, testdir.join(request.function.__name__))
+        for d in (basedir, datadir):
+            testdir = d.join(request.module.__name__)
+            if request.cls is not None:
+                clsdir = testdir.join(request.cls.__name__)
+                self._datadirs.extend([
+                    clsdir.join(request.function.__name__),
+                    clsdir
+                ])
+            else:
+                self._datadirs.append(testdir.join(request.function.__name__))
+            self._datadirs.append(testdir)
+        self._datadirs.append(datadir)
 
     def __getitem__(self, path):
         for datadir in self._datadirs:
@@ -121,6 +128,8 @@ def datadir(request):
 
     - ``tests/test_one/test_func/``
     - ``tests/test_one/``
+    - ``tests/data/test_one/test_func/``
+    - ``tests/data/test_one/``
     - ``tests/data/``
 
     The path to the first existing file (or directory) is returned as a
@@ -134,6 +143,9 @@ def datadir(request):
     - ``tests/test_two/TestClass/test_method/``
     - ``tests/test_two/TestClass/``
     - ``tests/test_two/``
+    - ``tests/data/test_two/TestClass/test_method/``
+    - ``tests/data/test_two/TestClass/``
+    - ``tests/data/test_two/``
     - ``tests/data/``
 
     Here, this would return the path

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,39 @@
+from mock import MagicMock
+import py.path
+
+from pytest_datadir_ng import _Datadir
+
+
+def test_datadir():
+    request = MagicMock()
+    basedir = py.path.local('tests')
+    datadir = basedir.join('data')
+    request.fspath.dirpath = MagicMock(return_value=basedir)
+
+    # tests.test_module.TestClass.test_method
+    request.module.__name__ = 'test_module'
+    request.cls.__name__ = 'TestClass'
+    request.function.__name__ = 'test_method'
+    d = _Datadir(request)
+    assert d._datadirs == [
+        basedir.join('test_module', 'TestClass', 'test_method'),
+        basedir.join('test_module', 'TestClass'),
+        basedir.join('test_module'),
+        datadir.join('test_module', 'TestClass', 'test_method'),
+        datadir.join('test_module', 'TestClass'),
+        datadir.join('test_module'),
+        datadir,
+    ]
+
+    # tests.test_module.test_function
+    request.module.__name__ = 'test_module'
+    request.cls = None
+    request.function.__name__ = 'test_function'
+    d = _Datadir(request)
+    assert d._datadirs == [
+        basedir.join('test_module', 'test_function'),
+        basedir.join('test_module'),
+        datadir.join('test_module', 'test_function'),
+        datadir.join('test_module'),
+        datadir,
+    ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py27,py33,py34,py35
+
+[testenv]
+deps=
+    pytest
+    mock
+commands=py.test tests.py


### PR DESCRIPTION
Some people prefer to keep all test data under `data/` directory. This pull request allows such configuration, while preserving compatibility with all existing configurations.

Changes:
1. Allow per-test directories under `data/`
   
   The relevant code section was also refactored to append directories to the list in order of priority, instead of confusing `insert(0, ...)` logic.
2. Added unit test to cover changes.
3. Updated comments and `README.rst`
4. Added `.gitignore` and `tox.ini`.

If you accept this pull request, please consider publishing `pytest-datadir-ng==1.1.0`, I would like to use it in my projects.
