### PR TITLE
Added class level fixture support

### DIFF
--- a/pytest_datadir_ng.py
+++ b/pytest_datadir_ng.py
@@ -200,3 +200,39 @@ def datadir_copy(request, tmpdir):
             fh = resource1.open("rb")
     """
     return _DatadirCopy(request, tmpdir)
+
+
+@pytest.fixture
+def datadir_class(request, datadir):
+    """Uses to set a ``client`` class attribute to the datadir::
+
+        @pytest.mark.usefixtures('datadir_class')
+        class TestFileThing:
+
+            def get_foo_file(self):
+                return self.datadir["foo.txt"]
+
+            def test_login(self):
+                assert os.path.exists(self.get_foo_file())
+
+    """
+    if request.cls is not None:
+        request.cls.datadir = datadir
+
+
+@pytest.fixture
+def datadir_copy_class(request, datadir_copy):
+    """Uses to set a ``client`` class attribute to the datadir_copy::
+
+        @pytest.mark.usefixtures('datadir_copy_class')
+        class TestFileThing:
+
+            def get_foo_file(self):
+                return self.datadir_copy["foo.txt"]
+
+            def test_login(self):
+                assert os.path.exists(self.get_foo_file())
+
+    """
+    if request.cls is not None:
+        request.cls.datadir_copy = datadir_copy


### PR DESCRIPTION
Added the ability to apply the fixture as a class member, using:

```
@pytest.mark.usefixtures('datadir_class')
class ThatNeedsFixture:
    pass
```

which will make it work for tests that calls method of that class (useful for _helper_ methods in mixins for example).
